### PR TITLE
Add function to apply `fill-region` in doc strings

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -505,6 +505,17 @@ just return nil."
   (let* ((output (elixir-mode--execute-elixir-with-code-string-to-quoted string)))
     (elixir-quoted--initialize-buffer output)))
 
+(defun elixir-mode-fill-doc-string ()
+  (interactive)
+  (save-excursion
+    (re-search-backward "@\\(?:module\\)?doc +\"\"\"" nil t)
+    (re-search-forward "\"\"\"" nil t)
+    (set-mark (point))
+    (re-search-forward "\"\"\"" nil t)
+    (re-search-backward "^ *\"\"\"" nil t)
+    (backward-char)
+    (fill-region (point) (mark))))
+
 (defun elixir-mode-eval-on-region (beg end)
   "Evaluate the Elixir code on the marked region.
 Argument BEG Start of the region.


### PR DESCRIPTION
This commit adds a function that helps one to keep documentation strings
under `fill-column` columns.

For example, consider the following doc strings:

```elixir
  @moduledoc """
  This is module documentation with a line that is waaaaayyy to long to be read. It's pretty bad when lines get wrapped in your editor or when you have to scroll horizontally to be able to see it well. Gosh, can Emacs relieve me of the pain of keeping documentation columns straight??
  """

Github adds horizontal scrolling to the lines above, which I find a real pain.

  @doc """
  This is module documentation with a line that is waaaaayyy to long to be read. It's pretty bad when lines get wrapped in your editor or when you have to scroll horizontally to be able to see it well. Gosh, can Emacs relieve me of the pain of keeping documentation columns straight??
  """
```

After calling `elixir-mode-fill-doc-string` the result would be:

```elixir
  @moduledoc """
  This is module documentation with a line that is waaaaayyy to long to be read.
  It's pretty bad when lines get wrapped in your editor or when you have to
  scroll horizontally to be able to see it well. Gosh, can Emacs relieve me of
  the pain of keeping documentation columns straight??
  """

  @doc """
  This is module documentation with a line that is waaaaayyy to long to be read.
  It's pretty bad when lines get wrapped in your editor or when you have to
  scroll horizontally to be able to see it well. Gosh, can Emacs relieve me of
  the pain of keeping documentation columns straight??
  """
```