### PR TITLE
Highlight module references equally

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -413,8 +413,7 @@ Argument FILE-NAME ."
 
 (defun elixir-quoted--initialize-buffer (quoted)
   (pop-to-buffer elixir-quoted--buffer-name)
-  (setq buffer-undo-list nil) ; Get rid of undo information from
-                                        ; previous expansions
+  (setq buffer-undo-list nil) ; Get rid of undo information from previous expansions
   (let ((inhibit-read-only t)
         (buffer-undo-list t)) ; Ignore undo information
     (erase-buffer)

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -305,6 +305,33 @@ for the Elixir programming language."
     (,(elixir-rx (group sigils))
      1 font-lock-builtin-face)
 
+    ;; Sigil patterns. Elixir has support for eight different sigil delimiters.
+    ;; This isn't a very DRY approach here but it gets the job done.
+    (,(elixir-rx sigils
+                 (and "/" (group (one-or-more (not (any "/")))) "/"))
+     1 font-lock-string-face)
+    (,(elixir-rx sigils
+                 (and "[" (group (one-or-more (not (any "]")))) "]"))
+     1 font-lock-string-face)
+    (,(elixir-rx sigils
+                 (and "{" (group (one-or-more (not (any "}")))) "}"))
+     1 font-lock-string-face)
+    (,(elixir-rx sigils
+                 (and "(" (group (one-or-more (not (any ")")))) ")"))
+     1 font-lock-string-face)
+    (,(elixir-rx sigils
+                 (and "|" (group (one-or-more (not (any "|")))) "|"))
+     1 font-lock-string-face)
+    (,(elixir-rx sigils
+                 (and "\"" (group (one-or-more (not (any "\"")))) "\""))
+     1 font-lock-string-face)
+    (,(elixir-rx sigils
+                 (and "'" (group (one-or-more (not (any "'")))) "'"))
+     1 font-lock-string-face)
+    (,(elixir-rx sigils
+                 (and "<" (group (one-or-more (not (any ">")))) ">"))
+     1 font-lock-string-face)
+
     ;; Regex patterns. Elixir has support for eight different regex delimiters.
     ;; This isn't a very DRY approach here but it gets the job done.
     (,(elixir-rx "~r"
@@ -387,7 +414,7 @@ Argument FILE-NAME ."
 (defun elixir-quoted--initialize-buffer (quoted)
   (pop-to-buffer elixir-quoted--buffer-name)
   (setq buffer-undo-list nil) ; Get rid of undo information from
-                              ; previous expansions
+                                        ; previous expansions
   (let ((inhibit-read-only t)
         (buffer-undo-list t)) ; Ignore undo information
     (erase-buffer)

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -201,25 +201,6 @@ for the Elixir programming language."
                                       "defexception" "defstruct" "defimpl"
                                       "defcallback")
                                   symbol-end))
-      (builtin-modules . ,(rx symbol-start
-                              (or "Agent" "Application" "Atom" "Base"
-                                  "Behaviour" "Bitwise" "Builtin" "Code" "Dict"
-                                  "EEx" "Elixir" "Enum" "ExUnit" "Exception"
-                                  "File" "File.Stat" "File.Stream" "Float"
-                                  "Function" "GenEvent" "GenServer" "GenTCP"
-                                  "HashDict" "HashSet" "IO" "IO.ANSI"
-                                  "IO.Stream" "Inspect.Algebra" "Inspect.Opts"
-                                  "Integer" "Kernel" "Kernel.ParallelCompiler"
-                                  "Kernel.ParallelRequire" "Kernel.SpecialForms"
-                                  "Kernel.Typespec" "Keyword" "List" "Macro"
-                                  "Macro.Env" "Map" "Math" "Module" "Node"
-                                  "OptionParser" "OrdDict" "Path" "Port"
-                                  "Process" "Protocol" "Range" "Record" "Regex"
-                                  "Set" "Stream" "String" "StringIO"
-                                  "Supervisor" "Supervisor.Spec" "System" "Task"
-                                  "Task.Supervisor" "Tuple" "URI"
-                                  "UnboundMethod" "Version")
-                              symbol-end))
       (builtin-namespace . ,(rx symbol-start
                                 (or "import" "require" "use" "alias")
                                 symbol-end))
@@ -229,8 +210,8 @@ for the Elixir programming language."
                          anything
                          symbol-end))
       (function-declaration . ,(rx symbol-start
-                       (or "def" "defp")
-                       symbol-end))
+                                   (or "def" "defp")
+                                   symbol-end))
       ;; Match `@doc' or `@moduledoc' syntax, with or without triple quotes.
       (heredocs . ,(rx symbol-start
                        (or "@doc" "@moduledoc" "~s")
@@ -259,7 +240,7 @@ for the Elixir programming language."
                            (zero-or-more
                             (and "."
                                  (one-or-more (any "A-Z" "_"))
-                                  (zero-or-more (any "A-Z" "a-z" "_" "0-9"))))
+                                 (zero-or-more (any "A-Z" "a-z" "_" "0-9"))))
                            (optional (or "!" "?"))
                            symbol-end))
       (operators1 . ,(rx symbol-start
@@ -295,12 +276,6 @@ for the Elixir programming language."
   `(
     ;; String interpolation
     (elixir-match-interpolation 0 font-lock-variable-name-face t)
-
-    ;; Module-defining & namespace builtins
-    (,(elixir-rx (or builtin-declaration builtin-namespace)
-                 space
-                 (group module-names))
-     1 font-lock-type-face)
 
     ;; Module attributes
     (,(elixir-rx (group (or heredocs
@@ -357,6 +332,10 @@ for the Elixir programming language."
                  (and "<" (group (one-or-more (not (any ">")))) ">"))
      1 font-lock-string-face)
 
+    ;; Modules
+    (,(elixir-rx (group module-names))
+     1 font-lock-type-face)
+
     ;; Atoms and singleton-like words like true/false/nil.
     (,(elixir-rx (group atoms))
      1 elixir-atom-face)
@@ -365,8 +344,8 @@ for the Elixir programming language."
     (,(elixir-rx (group (and (one-or-more identifiers) ":")))
      1 elixir-atom-face)
 
-    ;; Built-in modules and pseudovariables
-    (,(elixir-rx (group (or builtin-modules pseudo-var)))
+    ;; Pseudovariables
+    (,(elixir-rx (group pseudo-var))
      1 font-lock-constant-face)
 
     ;; Code points

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -32,7 +32,8 @@ buffer."
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "defmodule Application.Behavior do
-  use Application.Behaviour"
+  use Application.Behaviour
+  Stand.Alone.call"
    (should (eq (elixir-test-face-at 1) 'font-lock-keyword-face))
    (should (eq (elixir-test-face-at 11) 'font-lock-type-face))
    (should (eq (elixir-test-face-at 22) 'font-lock-type-face))
@@ -41,7 +42,10 @@ buffer."
    (should (eq (elixir-test-face-at 37) 'font-lock-keyword-face))
    (should (eq (elixir-test-face-at 41) 'font-lock-type-face))
    (should (eq (elixir-test-face-at 52) 'font-lock-type-face))
-   (should (eq (elixir-test-face-at 53) 'font-lock-type-face))))
+   (should (eq (elixir-test-face-at 53) 'font-lock-type-face))
+   (should (eq (elixir-test-face-at 68) 'font-lock-type-face))
+   (should (eq (elixir-test-face-at 72) 'font-lock-type-face))
+   (should (eq (elixir-test-face-at 79) nil))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-regex-with-quote ()
   "https://github.com/elixir-lang/emacs-elixir/issues/23"

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -28,6 +28,17 @@ buffer."
    ;; no face for regex delimiters
    (should (eq (elixir-test-face-at 15) nil))))
 
+(ert-deftest elixir-mode-syntax-table/sigils ()
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+   "asdfg = ~s{Capitalized noncapitalized}"
+   (should (eq (elixir-test-face-at 1) 'font-lock-variable-name-face))
+   (should (eq (elixir-test-face-at 9) 'elixir-attribute-face))
+   (should (eq (elixir-test-face-at 12) 'font-lock-string-face))
+   (should (eq (elixir-test-face-at 26) 'font-lock-string-face))
+   ;; no face for regex delimiters
+   (should (eq (elixir-test-face-at 38) nil))))
+
 (ert-deftest elixir-mode-syntax-table/fontify-modules-and-types ()
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -56,6 +56,7 @@ buffer."
    (should (eq (elixir-test-face-at 53) 'font-lock-type-face))
    (should (eq (elixir-test-face-at 68) 'font-lock-type-face))
    (should (eq (elixir-test-face-at 72) 'font-lock-type-face))
+   ;; no face for function call
    (should (eq (elixir-test-face-at 79) nil))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-regex-with-quote ()
@@ -140,13 +141,15 @@ end"
   (elixir-test-with-temp-buffer
       ":oriole
 :andale
-:ms2pid"
+:ms2pid
+:CapitalizedAtom"
     (should (eq (elixir-test-face-at 3) 'elixir-atom-face))
     (should (eq (elixir-test-face-at 5) 'elixir-atom-face))
     (should (eq (elixir-test-face-at 10) 'elixir-atom-face))
     (should (eq (elixir-test-face-at 13) 'elixir-atom-face))
     (should (eq (elixir-test-face-at 18) 'elixir-atom-face))
-    (should (eq (elixir-test-face-at 23) 'elixir-atom-face))))
+    (should (eq (elixir-test-face-at 23) 'elixir-atom-face))
+    (should (eq (elixir-test-face-at 26) 'elixir-atom-face))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-map-keys ()
   :tags '(fontification map syntax-table)


### PR DESCRIPTION
This PR sets `module` fontlock to be consistent across references. This PR also removes the notion of highlighting built-in modules differently than *user/custom* modules. 

Concerning the risk of wrongly highlighting capitalized words that do not correspond to module references, the picture below sumarizes the changes in highlighting:

![screenshot from 2015-03-18 23 37 37](https://cloud.githubusercontent.com/assets/4231743/6723516/ccefaf90-cdc7-11e4-97de-bfa96d7b7163.png)

To the left, the current behavior and to the right the proposed ones.

UPDATE:
I fontified the contents of sigils with `string-font-lock-face` just like the regexp does.

The new result is as follows:

![screenshot from 2015-03-20 20 12 35](https://cloud.githubusercontent.com/assets/4231743/6762360/79b12bac-cf3d-11e4-8d5f-8d7f3786a8d4.png)

Fixes #166 