### PR TITLE
Remove redundant local-pair tip for smartparens users

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,6 @@ blocks. A sample configuration would be:
   (sp-local-pair "do" "end"
 		 :when '(("SPC" "RET"))
 		 :post-handlers '(sp-ruby-def-post-handler)
-		 :actions '(insert navigate))
-  (sp-local-pair "case" "end"
-		 :when '(("SPC" "RET"))
-		 :post-handlers '(sp-ruby-def-post-handler)
 		 :actions '(insert navigate)))
 ```
 


### PR DESCRIPTION
Turns out the last tip for "case" "end" is not actually needed.

We should probably remove it then.