### PR TITLE
correct indentation for multiclause anonymous functions

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -291,7 +291,10 @@
      (smie-rule-parent))
     ;; Closing paren on the other line
     (`(:before . "(")
-     (smie-rule-parent))
+     (cond
+      ((smie-rule-parent-p "fn")
+       (smie-rule-parent elixir-smie-indent-basic))
+      (t (smie-rule-parent))))
     (`(:before . "[")
      (cond
       ((smie-rule-hanging-p)

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -965,7 +965,6 @@ def foo(test) do
   run(test_case)
 end")
 
-;; Will pass when #180 is resolved.
 (elixir-def-indentation-test indent-after-bitstring/1
                              (:tags '(indentation))
 "
@@ -979,6 +978,29 @@ defmodule X do
   def a, do: <<1 :: size(8)>>
   def b, do: <<2 :: size(8)>>
   def c, do: <<3 :: size(8)>>
+end")
+
+(elixir-def-indentation-test indent-after-fn/1
+                             (:tags '(indentation))
+"
+defmodule X do
+  def func do
+    Enum.filter([1,2,3],
+      fn(1) -> true
+             (2) -> false
+  (_) -> true
+      end)
+  end
+end"
+"
+defmodule X do
+  def func do
+    Enum.filter([1,2,3],
+      fn(1) -> true
+        (2) -> false
+        (_) -> true
+      end)
+  end
 end")
 
 ;; We don't want automatic whitespace cleanup here because of the significant


### PR DESCRIPTION
This fixes #184 

Behavior before

```elixir
defmodule X do
  def func do
    Enum.filter([1,2,3],
      fn(1) -> true
      (2) -> false
        (_) -> true
      (3) -> true
        (_) -> true
      end)
  end
end
```

Behavior after

```elixir
defmodule X do
  def func do
    Enum.filter([1,2,3],
      fn(1) -> true
        (2) -> false
        (_) -> true
        (3) -> true
        (_) -> true
      end)
  end
end
```