### PR TITLE
Fix (error "Lisp nesting exceeds `max-lisp-eval-depth'") which crashes correct indentation

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -194,7 +194,7 @@
           (forward-char)
           (self-call))
          ((looking-at elixir-smie--spaces-til-eol-regexp)
-          (move-beginning-of-line 2)
+          (forward-char)
           (self-call))
          ;; And if we're NOT on a blank line, move to the end of the line, and see
          ;; if we're looking back at a block operator.


### PR DESCRIPTION
It fixes #168 

If you try to indent on a blank line, one line before the last blank line in the buffer the following error raises and crashes the indentation.

```el
(error "Lisp nesting exceeds `max-lisp-eval-depth'") 
```

Example:

```elixir
1 defmodule Application.Behavior do
2
3   def something(arg) do
4
5   end
6   -> try to indent here raises `(error "Lisp nesting exceeds `max-lisp-eval-depth'")`
7  
```