### PR TITLE
fix wrong indentation on empty line between existing code

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -284,7 +284,10 @@
      (cond
       ((and (not (smie-rule-sibling-p))
             (smie-rule-hanging-p))
-       (smie-rule-parent elixir-smie-indent-basic))))
+       (smie-rule-parent elixir-smie-indent-basic))
+      ((smie-rule-parent-p "MATCH-STATEMENT-DELIMITER")
+       (smie-rule-parent))
+      (t (smie-rule-parent elixir-smie-indent-basic))))
     (`(:before . "fn")
      (smie-rule-parent))
     (`(:before . "end")


### PR DESCRIPTION
fixes #165 

This fixes the problem of the wrong indentation when moving on a new empty line between existing code and the cursor get moved to the end of the line.

Examples:

```elixir
defmodule Math do
	def max(list) do
                        # ...when you start typing
    Enum.reduce list, 0, fn(x, acc) ->
      if x > acc, do: x, else: acc
    end
  end
end
```

```elixir
def generate_pkg(path, opts) do
  name = Path.basename(Path.expand(path))

  File.mkdir_p!(path)
                         # ...when you start typing
  File.cd! path, fn ->
    _generate_pkg(name, opts)
  end
end
````