### PR TITLE
correct indentation after one line definition with if keyword

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -368,6 +368,16 @@
         (t (smie-rule-parent elixir-smie-indent-basic))))))
     (`(:before . ";")
      (cond
+      ;; There is a case after an one line definition of functions/macros
+      ;; when an `if' keyword token is involved, where the next block `end'
+      ;; token will have a `if' as parent and it's hanging.
+      ;;
+      ;; Example:
+      ;;
+      ;; defmacro my_if(expr, do: if_block), do: if(expr, do: if_block, else: nil)
+      ;; defmacro my_if(expr, do: if_block, else: else_block) do
+      ;;   ...
+      ;; end <- parent is `if`
       ((and (smie-rule-parent-p "if")
             (smie-rule-hanging-p))
        (smie-rule-parent))

--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -330,6 +330,10 @@
       ((smie-rule-hanging-p)
        (smie-rule-parent elixir-smie-indent-basic))
       (t elixir-smie-indent-basic)))
+    (`(:before . "if")
+     (cond
+      ((smie-rule-parent-p ";")
+       (smie-rule-parent))))
     (`(:before . "->")
      (cond
       ((smie-rule-hanging-p)
@@ -364,9 +368,13 @@
         (t (smie-rule-parent elixir-smie-indent-basic))))))
     (`(:before . ";")
      (cond
+      ((and (smie-rule-parent-p "if")
+            (smie-rule-hanging-p))
+       (smie-rule-parent))
       ((smie-rule-parent-p "after" "catch" "def" "defmodule" "defp" "do" "else"
                            "fn" "if" "rescue" "try" "unless")
-       (smie-rule-parent elixir-smie-indent-basic))))
+       (smie-rule-parent elixir-smie-indent-basic))
+     ))
     (`(:after . ";")
      (cond
       ((smie-rule-parent-p "def")

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -873,6 +873,34 @@ defmodule Greeter do
   end
 end")
 
+(elixir-def-indentation-test indent-after-def-do-online/2
+                             (:tags '(indentation))
+
+"defmodule ControlFlow do
+  defmacro my_if(expr, do: if_block), do: if(expr, do: if_block, else: nil)
+                                          defmacro my_if(expr, do: if_block, else: else_block) do
+                                            quote do
+                                              case unquote(expr) do
+                                                result when result in [false, nil] -> unquote(else_block)
+                                                _ -> unquote(if_block)
+                                              end
+                                            end
+                                            end
+end"
+
+"defmodule ControlFlow do
+  defmacro my_if(expr, do: if_block), do: if(expr, do: if_block, else: nil)
+  defmacro my_if(expr, do: if_block, else: else_block) do
+    quote do
+      case unquote(expr) do
+        result when result in [false, nil] -> unquote(else_block)
+        _ -> unquote(if_block)
+      end
+    end
+  end
+end")
+
+
 (elixir-def-indentation-test indent-binary-sequence
                              (:tags '(indentation))
 "


### PR DESCRIPTION
fixes #212

### Before:

```elixir
defmodule ControlFlow do
  defmacro my_if(expr, do: if_block), do: if(expr, do: if_block, else: nil)
                                          defmacro my_if(expr, do: if_block, else: else_block) do
                                            quote do
                                              case unquote(expr) do
                                                result when result in [false, nil] -> unquote(else_block)
                                                _ -> unquote(if_block)
                                              end
                                            end
                                            end
end
```

### After:

```elixir
defmodule ControlFlow do
  defmacro my_if(expr, do: if_block), do: if(expr, do: if_block, else: nil)
  defmacro my_if(expr, do: if_block, else: else_block) do
    quote do
      case unquote(expr) do
        result when result in [false, nil] -> unquote(else_block)
        _ -> unquote(if_block)
      end
    end
  end
end
```