### PR TITLE
correct indentation inside heredoc strings

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -398,6 +398,53 @@
               (smie-rule-hanging-p)))
        (smie-rule-parent elixir-smie-indent-basic))))))
 
+(defun elixir-smie--heredoc-at-current-point-p ()
+  "Return non-nil if cursor is at a string."
+  (save-excursion
+    (or (and (nth 3 (save-excursion
+                      (let ((pos (point)))
+                        (parse-partial-sexp 1 pos))))
+             (nth 8 (save-excursion
+                      (let ((pos (point)))
+                        (parse-partial-sexp 1 pos)))))
+        (and (looking-at "\"\"\"")
+           (match-beginning 0)))))
+
+(defun elixir-smie--previous-line-empty-p ()
+  "Return non-nil if the previous line is blank."
+  (save-excursion
+    (forward-line -1)
+    (and (eolp) (bolp))))
+
+(defun elixir-smie--previous-line-indentation ()
+  "Return the indentation of the previous line."
+  (save-excursion
+    (forward-line -1)
+    (current-indentation)))
+
+;; Add the custom function to handle indentation inside heredoc to the
+;; smie-indent-functions list. The indentation function will only be
+;; process inside an elixir-mode.
+(defun elixir-smie--indent-inside-heredoc ()
+  "Handle indentation inside Elixir heredocs.
+
+Rules:
+  1. If the previous line is empty, indent as the basic indentation
+     at the beginning of the heredoc.
+  2. If the previous line is not empty, indent as the previous line.
+"
+  (if (eq major-mode 'elixir-mode)
+      (if (elixir-smie--heredoc-at-current-point-p)
+          (let ((indent
+                 (save-excursion
+                   (when (re-search-backward "^\\(\s+\\).+\"\"\"" nil t)
+                     (string-width (match-string 1))))))
+            (if (elixir-smie--previous-line-empty-p)
+                (goto-char indent)
+              (goto-char (elixir-smie--previous-line-indentation)))))))
+
+(add-to-list 'smie-indent-functions 'elixir-smie--indent-inside-heredoc)
+
 (provide 'elixir-smie)
 
 ;;; elixir-smie.el ends here

--- a/test/elixir-mode-helper-test.el
+++ b/test/elixir-mode-helper-test.el
@@ -1,0 +1,77 @@
+;;; elixir-mode-helper-test.el --- Tests for helper functions
+
+;;; Code:
+
+(ert-deftest check-if-currently-inside-heredoc ()
+  (should (with-temp-buffer
+            (elixir-mode)
+            (insert "
+defmodule Module.Name do
+
+  @moduledoc \"\"\"
+  ## Examples
+
+  ....
+  \"\"\"
+
+end")
+            (goto-line 7)
+            (elixir-smie--heredoc-at-current-point-p)))
+  (should (not (with-temp-buffer
+                 (elixir-mode)
+                 (insert "
+defmodule Module.Name do
+
+  @moduledoc \"\"\"
+  ## Examples
+
+  ....
+  \"\"\"
+
+end")
+                 (goto-line 3)
+                 (elixir-smie--heredoc-at-current-point-p)))))
+
+(ert-deftest get-previous-line-indentation ()
+  (should (equal 2
+                 (with-temp-buffer
+                   (elixir-mode)
+                   (insert "
+defmodule Module.Name do
+  def what do
+    1 + 1
+  end
+end")
+                   (goto-line 4)
+                   (elixir-smie--previous-line-indentation))))
+  )
+
+
+(ert-deftest check-if-previous-line-blank ()
+  (should (not (with-temp-buffer
+                 (elixir-mode)
+                 (insert "
+defmodule Module.Name do
+
+  def what do
+    1 + 1
+  end
+end")
+                 (goto-line 3)
+                 (elixir-smie--previous-line-empty-p))))
+  (should (with-temp-buffer
+            (elixir-mode)
+            (insert "
+defmodule Module.Name do
+
+
+  def what do
+    1 + 1
+  end
+end")
+            (goto-line 4)
+            (elixir-smie--previous-line-empty-p))))
+
+(provide 'elixir-mode-helper-test)
+
+;;; elixir-mode-helper-test.el ends here

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -601,7 +601,7 @@ end
 ")
 
 (elixir-def-indentation-test indent-heredoc
-                             (:expected-result :failed :tags '(indentation))
+                             (:tags '(indentation))
   "
 defmodule Foo do
 @doc \"\"\"
@@ -621,6 +621,47 @@ defmodule Foo do
   \"\"\"
   def convert do
     x = 15
+  end
+end
+")
+
+(elixir-def-indentation-test indent-heredoc/2
+                             (:tags '(indentation))
+  "
+defmodule Foo do
+@doc \"\"\"
+this is a heredoc string
+
+\"\"\"
+def convert do
+x = 15
+end
+
+defmodule Bar do
+@moduledoc \"\"\"
+this is a heredoc string
+
+last line
+\"\"\"
+end
+end
+"
+  "
+defmodule Foo do
+  @doc \"\"\"
+  this is a heredoc string
+
+  \"\"\"
+  def convert do
+    x = 15
+  end
+
+  defmodule Bar do
+    @moduledoc \"\"\"
+    this is a heredoc string
+
+    last line
+    \"\"\"
   end
 end
 ")


### PR DESCRIPTION
### Handle indentation inside Elixir heredocs.

Rules:
  1. If the previous line is empty, indent as the basic indentation
      at the beginning of the heredoc.
  2. If the previous line is not empty, indent as the previous line.

fixes #86

/cc @mattdeboard 