### PR TITLE
correct indentation for block with multiple matches

### DIFF
--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1184,6 +1184,52 @@ defmodule Foo do
 end
 ")
 
+(elixir-def-indentation-test complex-case-with-matches (:tags '(indentation))
+"
+case parse do
+{ [ help: true ], _, _ }
+                  -> :help
+{ _, [ user, project, count ], _ } ->
+{ user, project, count }
+              { _, [ user, project ], _ } -> { user, project, @default_count }
+{ _, [ _, project ], _ } -> { _, project, @default_count }
+_ -> :help
+end"
+"
+case parse do
+  { [ help: true ], _, _ }
+    -> :help
+  { _, [ user, project, count ], _ } ->
+    { user, project, count }
+  { _, [ user, project ], _ } -> { user, project, @default_count }
+  { _, [ _, project ], _ } -> { _, project, @default_count }
+  _ -> :help
+end")
+
+
+(elixir-def-indentation-test complex-case-with-matches/2 (:tags '(indentation))
+"
+case parse do
+{ [ help: true ], _, _ }
+           -> :help
+{ _, [ user, project, count ], _ }
+    -> { user, project, count }
+  { _, [ user, project ], _ }
+  -> { user, project, @default_count }
+  _ -> :help
+end"
+"
+case parse do
+  { [ help: true ], _, _ }
+    -> :help
+  { _, [ user, project, count ], _ }
+    -> { user, project, count }
+  { _, [ user, project ], _ }
+    -> { user, project, @default_count }
+  _ -> :help
+end")
+
+
 ;; We don't want automatic whitespace cleanup here because of the significant
 ;; whitespace after `Record' above. By setting `whitespace-action' to nil,
 ;; `whitespace-mode' won't automatically clean up trailing whitespace (in my


### PR DESCRIPTION
#227 

This PR refines the indentation for block of matches.

```ex
case parse do
  { [ help: true ], _, _ }
    -> :help
  { _, [ user, project, count ], _ } ->
    { user, project, count }
  { _, [ user, project ], _ } -> { user, project, @default_count }
  _ -> :help
end

case parse do
  { [ help: true ], _, _ }
    -> :help
  { _, [ user, project, count ], _ }
    -> { user, project, count }
  { _, [ user, project ], _ }
    -> { user, project, @default_count }
  _ -> :help
  asd -> asda
  asdasd ->
    asd
  asd ->
    asd
    asd
  asdasd -> asdad
  asdasd ->
    asdasd
  { [ help: true ], _, _ }
    -> :help
  { _, [ user, project, count ], _ }
    -> { user, project, count }
  { _, [ user, project ], _ }
    -> { user, project, @default_count }
  _ -> :help
  { _, [ user, project ], _ } -> { user, project, @default_count }
  { _, [ _, project ], _ } -> { _, project, @default_count }
end
```