### PR TITLE
correct indentation for identifiers which contains built in words after a dot

### DIFF
--- a/test/elixir-mode-helper-test.el
+++ b/test/elixir-mode-helper-test.el
@@ -72,6 +72,107 @@ end")
             (goto-line 4)
             (elixir-smie--previous-line-empty-p))))
 
+
+;;; elixir-mode-helper-test.el --- Tests for helper functions
+
+;;; Code:
+
+(ert-deftest check-if-currently-inside-heredoc ()
+  (should (with-temp-buffer
+            (elixir-mode)
+            (insert "
+defmodule Module.Name do
+
+  @moduledoc \"\"\"
+  ## Examples
+
+  ....
+  \"\"\"
+
+end")
+            (goto-line 7)
+            (elixir-smie--heredoc-at-current-point-p)))
+  (should (not (with-temp-buffer
+                 (elixir-mode)
+                 (insert "
+defmodule Module.Name do
+
+  @moduledoc \"\"\"
+  ## Examples
+
+  ....
+  \"\"\"
+
+end")
+                 (goto-line 3)
+                 (elixir-smie--heredoc-at-current-point-p)))))
+
+(ert-deftest get-previous-line-indentation ()
+  (should (equal 2
+                 (with-temp-buffer
+                   (elixir-mode)
+                   (insert "
+defmodule Module.Name do
+  def what do
+    1 + 1
+  end
+end")
+                   (goto-line 4)
+                   (elixir-smie--previous-line-indentation))))
+  )
+
+
+(ert-deftest check-if-previous-line-blank ()
+  (should (not (with-temp-buffer
+                 (elixir-mode)
+                 (insert "
+defmodule Module.Name do
+
+  def what do
+    1 + 1
+  end
+end")
+                 (goto-line 3)
+                 (elixir-smie--previous-line-empty-p))))
+  (should (with-temp-buffer
+            (elixir-mode)
+            (insert "
+defmodule Module.Name do
+
+
+  def what do
+    1 + 1
+  end
+end")
+            (goto-line 4)
+            (elixir-smie--previous-line-empty-p))))
+
+
+(ert-deftest test-current-line-contains-built-in-keyword ()
+  (should (not (with-temp-buffer
+                 (elixir-mode)
+                 (insert "
+defmodule Module.Name do
+
+  def hey(test) do
+    test.case
+  end
+end")
+                 (goto-line 4)
+                 (elixir-smie-current-line-contains-built-in-keyword-p))))
+  (should (not (with-temp-buffer
+                 (elixir-mode)
+                 (insert "
+defmodule Module.Name do
+
+  def hey(test) do
+    case do
+    end
+  end
+end")
+                 (goto-line 4)
+                 (elixir-smie-current-line-contains-built-in-keyword-p)))))
+
 (provide 'elixir-mode-helper-test)
 
 ;;; elixir-mode-helper-test.el ends here

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1022,18 +1022,73 @@ children = [
   worker(Task, [KVServer, :accept, [4040]])
 ]")
 
-(elixir-def-indentation-test indent-after-reserved-word/1
-                             (:expected-result :failed :tags '(indentation))
-;; Will pass when #170 is resolved.
+(elixir-def-indentation-test indent-after-reserved-word/case
+                             (:tags '(indentation))
 "
+defmodule Application.Behavior do
 def foo(test) do
   test_case = test.case
   run(test_case)
+end
 end"
 "
+defmodule Application.Behavior do
+  def foo(test) do
+    test_case = test.case
+    run(test_case)
+  end
+end")
+
+(elixir-def-indentation-test indent-after-reserved-word/try
+                             (:tags '(indentation))
+"
+defmodule Application.Behavior do
 def foo(test) do
-  test_case = test.case
-  run(test_case)
+  test_case = test.try
+run(test_case)
+    end
+end"
+"
+defmodule Application.Behavior do
+  def foo(test) do
+    test_case = test.try
+    run(test_case)
+  end
+end")
+
+(elixir-def-indentation-test indent-after-reserved-word/rescue
+                             (:tags '(indentation))
+"
+defmodule Application.Behavior do
+def foo(test) do
+test_case = test.rescue
+           run(test_case)
+    end
+end"
+"
+defmodule Application.Behavior do
+  def foo(test) do
+    test_case = test.rescue
+    run(test_case)
+  end
+end")
+
+
+(elixir-def-indentation-test indent-after-reserved-word/if
+                             (:tags '(indentation))
+"
+defmodule Application.Behavior do
+def foo(test) do
+test_case = test.if
+           run(test_case)
+    end
+end"
+"
+defmodule Application.Behavior do
+  def foo(test) do
+    test_case = test.if
+    run(test_case)
+  end
 end")
 
 (elixir-def-indentation-test indent-after-bitstring/1


### PR DESCRIPTION
#170 

```ex
defmodule Application.Behavior do
  use Application.Behaviour

  def foo(test) do
    test_case = test.case
    run(test_case)
  end

  def hello(buddy) do
    Parser.if
    List.defmodule
    friend = buddy.try
    hug(friend)
  end
end

```