### PR TITLE
Correct indent in case expression when returning a tuple

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -410,7 +410,18 @@
       ;;   { _, [ user, project, count ], _ }
       ((and (not (smie-rule-hanging-p))
             (smie-rule-parent-p "do"))
-       (smie-rule-parent))
+       ;; If the last line ends with a block operator `->'
+       ;; indent two spaces more
+       ;;
+       ;; Example
+       ;;
+       ;; case File.read("/usr/share/dict/words") do
+       ;;   {:ok, contents} ->
+       ;;     {:something, contents} <- Indent here two spaces
+       ;;   ...
+       (if (elixir-smie-last-line-end-with-block-operator-p)
+           (smie-rule-parent elixir-smie-indent-basic)
+         (smie-rule-parent)))
       ((and (smie-rule-parent-p "MATCH-STATEMENT-DELIMITER")
             (not (smie-rule-hanging-p)))
        (if (elixir-smie-last-line-end-with-block-operator-p)

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1286,6 +1286,29 @@ case parse do
   _ -> :help
 end")
 
+(elixir-def-indentation-test complex-case-with-matches/3
+                             (:tags '(indentation))
+"
+defmodule MyModule do
+case File.read(\"/usr/share/dict/words\") do
+{:ok, contents} ->
+    {:something, contents}
+      {:error, reason} ->
+{:error, reason}
+  end
+end
+"
+"
+defmodule MyModule do
+  case File.read(\"/usr/share/dict/words\") do
+    {:ok, contents} ->
+      {:something, contents}
+    {:error, reason} ->
+      {:error, reason}
+  end
+end
+")
+
 (elixir-def-indentation-test close-map-curly-brackt
                              (:tags '(indentation))
 "


### PR DESCRIPTION
fixes #238 