### PR TITLE
Fix after dot highlighting

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -130,18 +130,21 @@
                       (zero-or-more (any "a-z" "A-Z" "0-9" "_" "\"" "'")))
                      (and "\"" (one-or-more (not (any "\""))) "\"")
                      (and "'" (one-or-more (not (any "'"))) "'"))))
-      (builtin . ,(rx symbol-start
+      (builtin . ,(rx (or line-start (not (any ".")))
+                      symbol-start
                       (or "case" "cond" "for" "if" "unless" "try" "receive"
                           "raise" "quote" "unquote" "unquote_splicing" "throw"
                           "super")
                       symbol-end))
-      (builtin-declaration . ,(rx symbol-start
+      (builtin-declaration . ,(rx (or line-start (not (any ".")))
+                                  symbol-start
                                   (or "def" "defp" "defmodule" "defprotocol"
                                       "defmacro" "defmacrop" "defdelegate"
                                       "defexception" "defstruct" "defimpl"
                                       "defcallback")
                                   symbol-end))
-      (builtin-namespace . ,(rx symbol-start
+      (builtin-namespace . ,(rx (or line-start (not (any ".")))
+                                symbol-start
                                 (or "import" "require" "use" "alias")
                                 symbol-end))
       ;; Set aside code point syntax for `elixir-negation-face'.
@@ -149,7 +152,8 @@
                          "?"
                          anything
                          symbol-end))
-      (function-declaration . ,(rx symbol-start
+      (function-declaration . ,(rx (or line-start (not (any ".")))
+                                   symbol-start
                                    (or "def" "defp")
                                    symbol-end))
       ;; Match `@doc' or `@moduledoc' syntax, with or without triple quotes.
@@ -162,10 +166,12 @@
       (identifiers . ,(rx (one-or-more (any "A-Z" "a-z" "_"))
                           (zero-or-more (any "A-Z" "a-z" "0-9" "_"))
                           (optional (or "?" "!"))))
-      (keyword . ,(rx symbol-start
+      (keyword . ,(rx (or line-start (not (any ".")))
+                      symbol-start
                       (or "fn" "do" "end" "after" "else" "rescue" "catch")
                       symbol-end))
-      (keyword-operator . ,(rx symbol-start
+      (keyword-operator . ,(rx (or line-start (not (any ".")))
+                               symbol-start
                                (or "not" "and" "or" "when" "in")
                                symbol-end))
       ;; Module and submodule names start with upper case letter. This

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -257,6 +257,31 @@ some_expr"
    (should (eq (elixir-test-face-at 6) 'font-lock-variable-name-face))
    (should (eq (elixir-test-face-at 12) 'font-lock-variable-name-face))))
 
+(ert-deftest elixir-mode-syntax-table/fontify-keyword-after-dot ()
+  "https://github.com/elixir-lang/emacs-elixir/issues/250"
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+   "Mix.raise
+raise
+Mix.def foo
+Mix.import
+import
+Mix.after
+after
+Mix.when
+when"
+   (should-not (eq (elixir-test-face-at 5) 'font-lock-keyword-face))
+   (should (eq (elixir-test-face-at 11) 'font-lock-keyword-face))
+   (should-not (eq (elixir-test-face-at 21) 'font-lock-keyword-face))
+   (should-not (eq (elixir-test-face-at 25) 'font-lock-function-name-face))
+   (should-not (eq (elixir-test-face-at 33) 'font-lock-keyword-face))
+   (should (eq (elixir-test-face-at 40) 'font-lock-keyword-face))
+
+   (should-not (eq (elixir-test-face-at 51) 'font-lock-keyword-face))
+   (should (eq (elixir-test-face-at 57) 'font-lock-keyword-face))
+   (should-not (eq (elixir-test-face-at 67) 'font-lock-keyword-face))
+   (should (eq (elixir-test-face-at 72) 'font-lock-keyword-face))))
+
 (provide 'elixir-mode-font-test)
 
 ;;; elixir-mode-font-test.el ends here


### PR DESCRIPTION
This is related to #250.

#### Original

![before](https://cloud.githubusercontent.com/assets/554281/9787301/91ba1090-57fc-11e5-98dc-45bd224cf18a.png)

#### With this change

![after](https://cloud.githubusercontent.com/assets/554281/9787303/97365a38-57fc-11e5-9d6f-a0b80b3d80af.png)

Please review this change.