### PR TITLE
Fix Highlight atom issue(atom contains '!', '?', '@')

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -127,7 +127,7 @@
                     (or
                      (and
                       (any "a-z" "A-Z" "_" "\"" "'")
-                      (zero-or-more (any "a-z" "A-Z" "0-9" "_" "\"" "'")))
+                      (zero-or-more (any "a-z" "A-Z" "0-9" "_" "\"" "'" "!" "@" "?")))
                      (and "\"" (one-or-more (not (any "\""))) "\"")
                      (and "'" (one-or-more (not (any "'"))) "'"))))
       (builtin . ,(rx (or line-start (not (any ".")))

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -174,6 +174,9 @@ true
 false
 nil
 true_false_nil
+:insert!
+:insert@
+:insert?
 "
     (should (eq (elixir-test-face-at 3) 'elixir-atom-face))
     (should (eq (elixir-test-face-at 5) 'elixir-atom-face))
@@ -185,7 +188,10 @@ true_false_nil
     (should (eq (elixir-test-face-at 43) 'elixir-atom-face))
     (should (eq (elixir-test-face-at 48) 'elixir-atom-face))
     (should (eq (elixir-test-face-at 54) 'elixir-atom-face))
-    (should-not (eq (elixir-test-face-at 57) 'elixir-atom-face))))
+    (should-not (eq (elixir-test-face-at 57) 'elixir-atom-face))
+    (should (eq (elixir-test-face-at 74) 'elixir-atom-face))
+    (should (eq (elixir-test-face-at 82) 'elixir-atom-face))
+    (should (eq (elixir-test-face-at 97) 'elixir-atom-face))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-map-keys ()
   :tags '(fontification map syntax-table)


### PR DESCRIPTION
This is related to #251.

### Original

![before](https://cloud.githubusercontent.com/assets/554281/9788823/380de638-5807-11e5-8004-cc3fadc8e3f5.png)


### With this change

![after](https://cloud.githubusercontent.com/assets/554281/9788833/3e558bea-5807-11e5-8eb1-865a62456819.png)

