### PR TITLE
Emacs hangs if `elixir-smie-forward-token` returns an empty string

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -635,6 +635,12 @@ Rules:
                 (goto-char indent)
               (goto-char (elixir-smie--previous-line-indentation)))))))
 
+(defun elixir-smie-empty-string-p (string)
+  "Return non-nil if STRING is null, blank or whitespace only."
+  (or (null string)
+      (string= string "")
+      (if (string-match-p "^\s+$" string) t)))
+
 (add-to-list 'smie-indent-functions 'elixir-smie--indent-inside-heredoc)
 
 (provide 'elixir-smie)

--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -260,7 +260,10 @@
    ((looking-at elixir-smie--operator-regexp)
     (goto-char (match-end 0))
     "OP")
-   (t (smie-default-forward-token))))
+   (t
+    (let ((token (smie-default-forward-token)))
+      (unless (elixir-smie-empty-string-p token)
+        token)))))
 
 (defun elixir-smie-backward-token ()
   (let ((pos (point)))

--- a/test/elixir-mode-helper-test.el
+++ b/test/elixir-mode-helper-test.el
@@ -173,6 +173,18 @@ end")
                  (goto-line 4)
                  (elixir-smie-current-line-contains-built-in-keyword-p)))))
 
+(ert-deftest test-if-string-is-empty ()
+  (should (equal (elixir-smie-empty-string-p nil)
+                 t))
+  (should (equal (elixir-smie-empty-string-p "")
+                 t))
+  (should (equal (elixir-smie-empty-string-p " ")
+                 t))
+  (should (equal (elixir-smie-empty-string-p "story")
+                 nil))
+  (should (equal (elixir-smie-empty-string-p "    ")
+                 t)))
+
 (provide 'elixir-mode-helper-test)
 
 ;;; elixir-mode-helper-test.el ends here


### PR DESCRIPTION
fixes #239