### PR TITLE
Indent receive/after matches correct

### DIFF
--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1383,6 +1383,37 @@ config = %{
   trace: opts[:trace]
 }")
 
+(elixir-def-indentation-test receive-after-block
+                             (:tags '(indentation))
+"
+receive do
+{:hello} -> :ok
+    other ->
+other
+    after
+2000 ->
+IO.puts 'hello'
+IO.puts 'status 2000 ends'
+{ :ok } ->
+IO.puts 'ok'
+_ -> whatever
+end
+"
+"
+receive do
+  {:hello} -> :ok
+  other ->
+    other
+after
+  2000 ->
+    IO.puts 'hello'
+    IO.puts 'status 2000 ends'
+  { :ok } ->
+    IO.puts 'ok'
+  _ -> whatever
+end
+")
+
 ;; We don't want automatic whitespace cleanup here because of the significant
 ;; whitespace after `Record' above. By setting `whitespace-action' to nil,
 ;; `whitespace-mode' won't automatically clean up trailing whitespace (in my


### PR DESCRIPTION
Example:

```ex
receive do
  {:hello} -> :ok
  other ->
    other
after
  2000 ->
    IO.puts 'hello' # <- Correct indentation
    IO.puts 'status 2000 ends' # <- Correct indentation
  { :ok } ->
    IO.puts 'ok'
  _ -> whatever # <- Correct indentation
end
```

fixes  #257