### PR TITLE
Correct indentation after "for" comprehension

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -121,9 +121,9 @@
                   ("try" "do" statements "catch" match-statements "end")
                   ("try" "do" statements "rescue" match-statements "end")
                   ("try" "do" statements "end")
-                  ("case" non-block-expr "do" match-statements "end"))
+                  ("case" non-block-expr "do" match-statements "end")
+                  ("for" non-block-expr "COMMA" "do:" non-block-expr))
        (non-block-expr (non-block-expr "OP" non-block-expr)
-                       (non-block-expr "COMMA" non-block-expr)
                        ("(" non-block-expr ")")
                        ("{" non-block-expr "}")
                        ("[" non-block-expr "]")
@@ -365,13 +365,25 @@
        (smie-rule-parent))))
     (`(:before . "fn")
      (smie-rule-parent))
+    (`(:before . "for")
+     (smie-rule-parent))
     (`(:before . "do:")
      (cond
       ((smie-rule-parent-p "def" "if" "defp" "defmacro" "defmacrop")
        (smie-rule-parent))
       ((and (smie-rule-parent-p ";")
             (not (smie-rule-hanging-p)))
-       (smie-rule-parent elixir-smie-indent-basic))))
+       (smie-rule-parent elixir-smie-indent-basic))
+      ;; Example
+      ;;
+      ;; hi = for i <- list, do: i
+      ;; # weird spacing now <- Indent
+      ;;
+      ;; for i <- list, do: i
+      ;; IO.puts 'WORKED' <- Indent
+      ((and (smie-rule-parent-p "for")
+            (not (smie-rule-hanging-p)))
+       (smie-rule-parent))))
     (`(:before . "do")
      (cond
       ((and (smie-rule-parent-p "case")

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1383,6 +1383,7 @@ config = %{
   trace: opts[:trace]
 }")
 
+
 (elixir-def-indentation-test receive-after-block
                              (:tags '(indentation))
 "
@@ -1412,6 +1413,37 @@ after
     IO.puts 'ok'
   _ -> whatever
 end
+")
+
+(elixir-def-indentation-test indent-after-for-online-definition
+                             (:tags '(indentation))
+"
+defmodule Hello do
+  def hi do
+    hi = for i <- list, do: i
+             # weird spacing now
+
+         for i <- list, do: i
+IO.puts 'WORKED'
+  end
+end
+
+hi = for i <- list, do: i
+         # weird spacing now
+"
+"
+defmodule Hello do
+  def hi do
+    hi = for i <- list, do: i
+    # weird spacing now
+
+    for i <- list, do: i
+    IO.puts 'WORKED'
+  end
+end
+
+hi = for i <- list, do: i
+# weird spacing now
 ")
 
 ;; We don't want automatic whitespace cleanup here because of the significant


### PR DESCRIPTION
Example

```ex
defmodule Hello do
  def hi do
    hi = for i <- list, do: i
    # weird spacing now <- Correct indentation

    for i <- list, do: i
    IO.puts 'WORKED' # <-  Correct indentation
  end
end
```

fixes #256