### PR TITLE
Test for multi-line function calls without parenthesis

### DIFF
--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1525,6 +1525,34 @@ result =
   end
 ")
 
+(elixir-def-indentation-test indent-multiline-function-calls-without-parenthesis
+                             (:expected-result :failed :tags '(indentation))
+"
+some_method :arg1,
+:arg2
+other_method
+"
+"
+some_method :arg1,
+  :arg2
+other_method
+")
+
+(elixir-def-indentation-test indent-multiline-function-calls-without-parenthesis/2
+                             (:expected-result :failed :tags '(indentation))
+"
+some_method :arg1,
+arg1: 1,
+arg2: 2
+other_method
+"
+"
+some_method :arg1,
+  arg1: 1,
+  arg2: 2
+other_method
+")
+
 ;; We don't want automatic whitespace cleanup here because of the significant
 ;; whitespace after `Record' above. By setting `whitespace-action' to nil,
 ;; `whitespace-mode' won't automatically clean up trailing whitespace (in my


### PR DESCRIPTION
Added two test cases for method call without parenthesis, one with atoms being passed as arguments, and other with keyword list. Test cases are marked as `:expected-result :failed`.

Related to https://github.com/elixir-lang/emacs-elixir/issues/229.