### PR TITLE
~s is sigil, not attribute

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -157,10 +157,6 @@
                                    symbol-start
                                    (or "def" "defp")
                                    symbol-end))
-      ;; Match `@doc' or `@moduledoc' syntax, with or without triple quotes.
-      (heredocs . ,(rx symbol-start
-                       (or "@doc" "@moduledoc" "~s")
-                       symbol-end))
       ;; The first character of an identifier must be a letter or an underscore.
       ;; After that, they may contain any alphanumeric character + underscore.
       ;; Additionally, the final character may be either `?' or `!'.
@@ -317,9 +313,8 @@ is used to limit the scan."
     (elixir-match-interpolation 0 font-lock-variable-name-face t)
 
     ;; Module attributes
-    (,(elixir-rx (group (or heredocs
-                            (and "@" (1+ identifiers)))))
-     1 elixir-attribute-face)
+    (,(elixir-rx (and "@" (1+ identifiers)))
+     0 elixir-attribute-face)
 
     ;; Keywords
     (,(elixir-rx (group (or builtin builtin-declaration builtin-namespace

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -37,7 +37,7 @@ match=~r/foo/"
   (elixir-test-with-temp-buffer
    "asdfg = ~s{Capitalized noncapitalized}"
    (should (eq (elixir-test-face-at 1) 'font-lock-variable-name-face))
-   (should (eq (elixir-test-face-at 9) 'elixir-attribute-face))
+   (should (eq (elixir-test-face-at 9) 'font-lock-builtin-face))
    (should (eq (elixir-test-face-at 12) 'font-lock-string-face))
    (should (eq (elixir-test-face-at 26) 'font-lock-string-face))
    ;; no face for regex delimiters
@@ -159,8 +159,8 @@ end"
   :tags '(fontification heredoc syntax-table)
   (elixir-test-with-temp-buffer
       "~s\"\"\""
-    (should (eq (elixir-test-face-at 1) 'elixir-attribute-face))
-    (should (eq (elixir-test-face-at 2) 'elixir-attribute-face))
+    (should (eq (elixir-test-face-at 1) 'font-lock-builtin-face))
+    (should (eq (elixir-test-face-at 2) 'font-lock-builtin-face))
     (should (eq (elixir-test-face-at 3) 'font-lock-string-face))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-atoms ()
@@ -329,6 +329,7 @@ foo
    (should-not (eq (elixir-test-face-at 23) 'font-lock-string-face))
 
    (should-not (eq (elixir-test-face-at 25) 'font-lock-string-face))  ; ~s()
+   (should     (eq (elixir-test-face-at 25) 'font-lock-builtin-face)) ; ~s()
    (should-not (eq (elixir-test-face-at 29) 'font-lock-string-face))
 
    (should-not (eq (elixir-test-face-at 31) 'font-lock-string-face))  ; ~r[]


### PR DESCRIPTION
And remove heredoc regexp because elixir-mode.el uses propertize function
for highlighting heredocs and does not use heredoc regexp.