### PR TITLE
added font-lock to defoverridable

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -142,7 +142,7 @@
                                   (or "def" "defp" "defmodule" "defprotocol"
                                       "defmacro" "defmacrop" "defdelegate"
                                       "defexception" "defstruct" "defimpl"
-                                      "defcallback")
+                                      "defcallback" "defoverridable")
                                   symbol-end))
       (builtin-namespace . ,(rx (or line-start (not (any ".")))
                                 symbol-start

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -139,6 +139,19 @@ end"
     (should (eq (elixir-test-face-at 5) 'font-lock-function-name-face))
     (should (eq (elixir-test-face-at 8) 'font-lock-function-name-face))))
 
+(ert-deftest elixir-mode-syntax-table/fontify-defoverridable/1 ()
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+      "defmodule Foo do
+  defmacro __using__(_opts) do
+    quote do
+      def bar, do: :ok
+      defoverridable [bar: 0]
+    end
+  end
+end"
+    (should (eq (elixir-test-face-at 91) 'font-lock-keyword-face))))
+
 (ert-deftest elixir-mode-syntax-table/fontify-heredoc/1 ()
   :tags '(fontification heredoc syntax-table)
   (elixir-test-with-temp-buffer


### PR DESCRIPTION
`defoverridable` didn't seem to get syntax highlighting. I've added it to the `font-lock-keyword-face` to it.

Before:
![before](https://cloud.githubusercontent.com/assets/482052/10512308/bf7a43ac-733f-11e5-9543-0aeb95ed595c.png)

After:
![after](https://cloud.githubusercontent.com/assets/482052/10512311/c7b6d404-733f-11e5-88d4-03cae4a5948c.png)

I've done my best to add a unit-test. I am pretty new to this smie/font-lock stuff, so someone please review my code. Thanks.