### PR TITLE
Fix string interpolation

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -300,7 +300,7 @@ is used to limit the scan."
     (when (and pos (> pos (point)))
       (goto-char pos)
       (let ((value (get-text-property pos 'elixir-interpolation)))
-        (if (eq (car value) ?\")
+        (if (car value)
             (progn
               (set-match-data (cdr value))
               t)

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -241,7 +241,7 @@ some_expr"
       "\"\"\"foo\"bar\"baz #{1 + 2} is 3.\"\"\""
     (should (eq (elixir-test-face-at 1) 'font-lock-string-face))
     (should (eq (elixir-test-face-at 5) 'font-lock-string-face))
-    (should (eq (elixir-test-face-at 19) 'font-lock-string-face))
+    (should (eq (elixir-test-face-at 19) 'font-lock-variable-name-face))
     (should (eq (elixir-test-face-at 31) 'font-lock-string-face))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-atom-in-pattern-match ()


### PR DESCRIPTION
`syntax-ppss`(`parse-partial-sexp`) documents says following. Its value is not always character and I suppose it is enough whether its value is non-nil.

```
  3. non-nil if inside a string.
     (it is the character that will terminate the string,
      or t if the string should be terminated by a generic string delimiter.)
```

#### Before

![before](https://cloud.githubusercontent.com/assets/554281/10518542/e7b5b236-739c-11e5-904c-442340149940.png)

#### With this patch

![after](https://cloud.githubusercontent.com/assets/554281/10518547/ee034acc-739c-11e5-8f98-fdef466ed2d5.png)

This is related to #206.
