### PR TITLE
Fix highlighting hashmark in sigil

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -278,7 +278,7 @@ is used to limit the scan."
         (when (memq start-delim '(?' ?\"))
           (setq end (1+ end))
           (forward-char -1))
-        (while (re-search-forward "[\"']" end t)
+        (while (re-search-forward "[\"'#]" end t)
           (put-text-property (1- (point)) (point) 'syntax-table word-syntax))))))
 
 (defun elixir-syntax-propertize-function (start end)

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -362,6 +362,14 @@ foo
    (should     (eq (elixir-test-face-at 53) 'font-lock-string-face))
    (should     (eq (elixir-test-face-at 55) 'font-lock-string-face))))
 
+(ert-deftest elixir-mode-syntax-table/hashmark-in-sigils ()
+  "Don't treat hashmark in sigils as comment"
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+   "~s(# foo)"
+   (should-not (eq (elixir-test-face-at 4) 'font-lock-comment-face))
+   (should     (eq (elixir-test-face-at 6) 'font-lock-string-face))))
+
 (provide 'elixir-mode-font-test)
 
 ;;; elixir-mode-font-test.el ends here


### PR DESCRIPTION
#### Before

![before](https://cloud.githubusercontent.com/assets/554281/10533787/2a8ee2aa-7409-11e5-8eba-71947c962550.png)

#### With this patch

![after](https://cloud.githubusercontent.com/assets/554281/10533789/2ef2bf06-7409-11e5-8926-71fe280213b5.png)
