### PR TITLE
Added `send` and `send_after` to font lock

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -135,7 +135,7 @@
                       symbol-start
                       (or "case" "cond" "for" "if" "unless" "try" "receive"
                           "raise" "quote" "unquote" "unquote_splicing" "throw"
-                          "super")
+                          "super" "send" "send_after")
                       symbol-end))
       (builtin-declaration . ,(rx (or line-start (not (any ".")))
                                   symbol-start

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -301,6 +301,20 @@ when"
    (should-not (eq (elixir-test-face-at 67) 'font-lock-keyword-face))
    (should (eq (elixir-test-face-at 72) 'font-lock-keyword-face))))
 
+(ert-deftest elixir-mode-syntax-table/highlight-send-and-send-after ()
+  "Highlight both send and send_after as keywords"
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+   "defmodule Foo do
+  def bar(pid) do
+    send pid, :baz
+    send_after pid, :baz, 5000
+  end
+end"
+   (should (eq (elixir-test-face-at 40) 'font-lock-keyword-face))
+   (should (eq (elixir-test-face-at 60) 'font-lock-keyword-face))
+   (should (eq (elixir-test-face-at 65) 'font-lock-keyword-face))))
+
 (ert-deftest elixir-mode-syntax-table/string-interpolation-in-words-list ()
   "https://github.com/elixir-lang/emacs-elixir/issues/263"
   :tags '(fontification syntax-table)


### PR DESCRIPTION
I noticed that the syntax highlighter doesn't seem to highlight `send` and `send_after`. I figured that they needed to be highlighted as keywords, so I've added them to the buildin list.

I've added a unit test that should cover both `send` and `send_after`.