### PR TITLE
Removed send_after from highlighted keywords

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -135,7 +135,7 @@
                       symbol-start
                       (or "case" "cond" "for" "if" "unless" "try" "receive"
                           "raise" "quote" "unquote" "unquote_splicing" "throw"
-                          "super" "send" "send_after")
+                          "super" "send")
                       symbol-end))
       (builtin-declaration . ,(rx (or line-start (not (any ".")))
                                   symbol-start

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -301,19 +301,16 @@ when"
    (should-not (eq (elixir-test-face-at 67) 'font-lock-keyword-face))
    (should (eq (elixir-test-face-at 72) 'font-lock-keyword-face))))
 
-(ert-deftest elixir-mode-syntax-table/highlight-send-and-send-after ()
-  "Highlight both send and send_after as keywords"
+(ert-deftest elixir-mode-syntax-table/highlight-send ()
+  "Highlight send as a keyword"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "defmodule Foo do
   def bar(pid) do
     send pid, :baz
-    send_after pid, :baz, 5000
   end
 end"
-   (should (eq (elixir-test-face-at 40) 'font-lock-keyword-face))
-   (should (eq (elixir-test-face-at 60) 'font-lock-keyword-face))
-   (should (eq (elixir-test-face-at 65) 'font-lock-keyword-face))))
+   (should (eq (elixir-test-face-at 40) 'font-lock-keyword-face))))
 
 (ert-deftest elixir-mode-syntax-table/string-interpolation-in-words-list ()
   "https://github.com/elixir-lang/emacs-elixir/issues/263"


### PR DESCRIPTION
`send_after` has to be imported and comes from the Process-module.

`send` on the other hand is imported via `Kernel`, so it would make sense to still highlight this.

Gosh, my ears are red.