### PR TITLE
Fix syntax highlighting sigils in string

### DIFF
--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -392,6 +392,19 @@ foo
    (should-not (eq (elixir-test-face-at 19) 'font-lock-type-face))
    (should     (eq (elixir-test-face-at 21) 'font-lock-type-face))))
 
+(ert-deftest elixir-mode-syntax-table/sigils-in-string ()
+  "https://github.com/elixir-lang/emacs-elixir/issues/275"
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+   "@one 1
+@two \"~s\"
+@three :tre
+"
+   (should-not (eq (elixir-test-face-at 18) 'font-lock-string-face))
+   (should     (eq (elixir-test-face-at 19) 'elixir-attribute-face))
+   (should-not (eq (elixir-test-face-at 25) 'font-lock-string-face))
+   (should     (eq (elixir-test-face-at 26) 'elixir-atom-face))))
+
 (provide 'elixir-mode-font-test)
 
 ;;; elixir-mode-font-test.el ends here


### PR DESCRIPTION
This is related to #275. CC: @ianrumford 

#### Original

![before](https://cloud.githubusercontent.com/assets/554281/10682826/b9b61464-7975-11e5-8c31-8d246d2c16ae.png)

#### With this change

![after](https://cloud.githubusercontent.com/assets/554281/10682828/bfa74848-7975-11e5-8b4f-97823dc341ad.png)

