### PR TITLE
Fix indentation of single line fun declarations after single line fun declarations with when clauses

### DIFF
--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -941,6 +941,18 @@ end"
   end
 end")
 
+(elixir-def-indentation-test indent-after-def-do-online/3
+                             (:expected-result :failed :tags '(indentation))
+"defmodule Foo do
+  def bar(baz, quun \\\\ nil)
+  def bar(baz, quun) when baz == quun, do: baz
+                                 def bar(baz, quun), do: quun
+end"
+"defmodule Foo do
+  def bar(baz, quun \\\\ nil)
+  def bar(baz, quun) when baz == quun, do: baz
+  def bar(baz, quun), do: quun
+end")
 
 (elixir-def-indentation-test indent-after-not-finished-one-line-def
                              (:tags '(indentation))


### PR DESCRIPTION
Indentation seems to fail if a single-line function declaration comes after a single-line function declaration that contain a when-clause.

I think that I have to touch the smie stuff to fix this; this would probably up my elisp game, but if anyone wanna take this to the finish you are more than welcome :)

This PR is in relation to #276 