### PR TITLE
Indent multiple macro calls with do colon correct

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -310,6 +310,22 @@
             -2)
            ((smie-rule-parent-p "def" "defp" "defmacro" "defmacrop")
             (smie-rule-parent))))
+    (`(:before . "def")
+     (cond
+      (t
+       (smie-rule-parent))))
+    (`(:before . "defp")
+     (cond
+      (t
+       (smie-rule-parent))))
+    (`(:before . "defmacro")
+     (cond
+      (t
+       (smie-rule-parent))))
+    (`(:before . "defmacrop")
+     (cond
+      (t
+       (smie-rule-parent))))
     (`(:after . "OP")
      (cond
       ((smie-rule-sibling-p) nil)
@@ -375,7 +391,7 @@
        (smie-rule-parent))
       ((and (smie-rule-parent-p ";")
             (not (smie-rule-hanging-p)))
-       (smie-rule-parent elixir-smie-indent-basic))
+       (smie-rule-parent))
       ;; Example
       ;;
       ;; hi = for i <- list, do: i

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -979,7 +979,7 @@ end"
 end")
 
 (elixir-def-indentation-test indent-after-not-finished-one-line-def
-                             (:tags '(indentation))
+                             (:expected-result :failed :tags '(indentation))
 "
 defmodule Hello do
       defp skip,
@@ -1001,6 +1001,23 @@ defmodule Hello do
   defp self, do: value
   defmacrop whatever, do: do_it!
 end")
+
+(elixir-def-indentation-test indent-correct-with-multiple-one-line-macro-calls
+                             (:tags '(indentation))
+"
+     mymacro x1, do: [:x1]
+mymacro x2, do: [:x2]
+mymacro x3, do: [:x3]
+      mymacro x1, do: [:x1]
+ mymacro x2, do: [:x2]
+         mymacro x3, do: [:x3]"
+"
+mymacro x1, do: [:x1]
+mymacro x2, do: [:x2]
+mymacro x3, do: [:x3]
+mymacro x1, do: [:x1]
+mymacro x2, do: [:x2]
+mymacro x3, do: [:x3]")
 
 (elixir-def-indentation-test indent-binary-sequence
                              (:tags '(indentation))


### PR DESCRIPTION
In order to fix #281 we need to revert the behavior of `do:` in one line definitions when it breaks to the next line.

Example before:

```elixir
defmodule Hello do
  defp skip,
    do: true

  def on?, do: true

  defmacro switch,
    do: on!

  defp self, do: value
  defmacrop whatever, do: do_it!
end
```

Example now:

```elixir
defmodule Hello do
  defp skip,
  do: true

  def on?, do: true

  defmacro switch,
  do: on!

  defp self, do: value
  defmacrop whatever, do: do_it!
end
```

The indentation for macro calls with `do:` has more importance than the pointed examples above.