### PR TITLE
Fix sigil triple quotes

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -264,7 +264,7 @@ is used to limit the scan."
   (unless (elixir-syntax-in-string-or-comment-p)
     (let ((heredoc-p (save-excursion
                        (goto-char (match-beginning 0))
-                       (looking-at-p "~s\"\"\""))))
+                       (looking-at-p "~[sS]\"\"\""))))
       (unless heredoc-p
         (forward-char 1)
         (let* ((start-delim (char-after (1- (point))))

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -414,6 +414,18 @@ foo
    (should-not (eq (elixir-test-face-at 25) 'font-lock-string-face))
    (should     (eq (elixir-test-face-at 26) 'elixir-atom-face))))
 
+(ert-deftest elixir-mode-syntax-table/sigil-triple-quote ()
+  "https://github.com/elixir-lang/emacs-elixir/issues/286"
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+   "defmodule IEx do
+  @moduledoc ~S\"\"\"
+  Elixir's interactive shell.
+\"\"\"
+end
+"
+   (should (eq (elixir-test-face-at 33) 'font-lock-string-face))))
+
 (provide 'elixir-mode-font-test)
 
 ;;; elixir-mode-font-test.el ends here


### PR DESCRIPTION
This is related to #286.

![fix](https://cloud.githubusercontent.com/assets/554281/10781688/bf444dcc-7d8c-11e5-9098-6107335ab0d1.png)
