### PR TITLE
Demonstrate defstruct indention in a test case

### DIFF
--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1526,6 +1526,21 @@ hi = for i <- list, do: i
 # weird spacing now
 ")
 
+(elixir-def-indentation-test indent-multiline-defstruct-without-parens
+                             (:tags '(indentation))
+"
+defmodule User do
+defstruct first_name: \"first\",
+last_name: \"last\"
+end
+"
+"
+defmodule User do
+  defstruct first_name: \"first\",
+            last_name: \"last\"
+end
+")
+
 (elixir-def-indentation-test indent-oneline-for-after-assignment
                              (:expected-result :failed :tags '(indentation))
 "

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1527,7 +1527,7 @@ hi = for i <- list, do: i
 ")
 
 (elixir-def-indentation-test indent-multiline-defstruct-without-parens
-                             (:tags '(indentation))
+                             (:expected-result :failed :tags '(indentation))
 "
 defmodule User do
 defstruct first_name: \"first\",


### PR DESCRIPTION
Adds an expected to fail test case that demonstrates how multiline `defstruct` without parentheses should be indented.

See #294 for more details.