### PR TITLE
Gray out ignored variables

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -112,6 +112,16 @@
   "For use with atoms & map keys."
   :group 'font-lock-faces)
 
+(defvar elixir-ignored-var-face 'elixir-ignored-var-face)
+(defface elixir-ignored-var-face
+  '((((class color) (min-colors 88) (background light))
+     :foreground "#424242")
+    (((class color) (background dark))
+     (:foreground "#616161"))
+    (t nil))
+  "For use with ignored variables (starting with underscore)."
+  :group 'font-lock-faces)
+
 (eval-when-compile
   (defconst elixir-rx-constituents
     `(
@@ -404,6 +414,14 @@ is used to limit the scan."
                  (or (or sigils identifiers space)
                      (one-or-more "\n")))
      1 font-lock-variable-name-face)
+
+    ;; Gray out variables starting with "_"
+    (,(elixir-rx symbol-start
+                 (group (and "_"
+                             (any "A-Z" "a-z" "0-9"))
+                        (zero-or-more (any "A-Z" "a-z" "0-9" "_"))
+                        (optional (or "?" "!"))))
+     1 elixir-ignored-var-face)
 
     ;; Map keys
     (,(elixir-rx (group (and (one-or-more identifiers) ":")))

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -426,6 +426,33 @@ end
 "
    (should (eq (elixir-test-face-at 33) 'font-lock-string-face))))
 
+(ert-deftest elixir-mode-syntax-table/gray-out-ignored-var ()
+  "https://github.com/elixir-lang/emacs-elixir/issues/292"
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+   "variable
+    _var
+    _x
+    _x!
+    _x?
+    _
+    __MODULE__
+"
+   (should (eq (elixir-test-face-at 4) nil))
+   (should (eq (elixir-test-face-at 14) 'elixir-ignored-var-face))
+   (should (eq (elixir-test-face-at 15) 'elixir-ignored-var-face))
+   (should (eq (elixir-test-face-at 23) 'elixir-ignored-var-face))
+   (should (eq (elixir-test-face-at 24) 'elixir-ignored-var-face))
+   (should (eq (elixir-test-face-at 30) 'elixir-ignored-var-face))
+   (should (eq (elixir-test-face-at 32) 'elixir-ignored-var-face))
+   (should (eq (elixir-test-face-at 38) 'elixir-ignored-var-face))
+   (should (eq (elixir-test-face-at 40) 'elixir-ignored-var-face))
+   (should (eq (elixir-test-face-at 46) 'font-lock-constant-face))
+   (should (eq (elixir-test-face-at 46) 'font-lock-constant-face))
+   (should (eq (elixir-test-face-at 52) 'font-lock-constant-face))
+   (should (eq (elixir-test-face-at 53) 'font-lock-constant-face))
+   (should (eq (elixir-test-face-at 55) 'font-lock-constant-face))))
+
 (provide 'elixir-mode-font-test)
 
 ;;; elixir-mode-font-test.el ends here


### PR DESCRIPTION
This commit grays out variables whose name start with `_`. These
variables are meant to be ignored in the program. The fontification of
the single underscore matcher (`_`) and pseudo-variables like
`__MODULE__` & company where not modified.

See https://github.com/elixir-lang/emacs-elixir/issues/292.

Before this commit:

![screenshot from 2015-11-24 20 19 23](https://cloud.githubusercontent.com/assets/4231743/11382381/aa004aa8-92e8-11e5-9bac-2cafb64b7a84.png)

After this commit:

![screenshot from 2015-11-24 20 18 29](https://cloud.githubusercontent.com/assets/4231743/11382361/8fd43270-92e8-11e5-9f76-38dd2552841e.png)


Fixes #292

