### PR TITLE
Include - in punctuation syntax class

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -83,6 +83,12 @@
     ;; Note that ?_ might be better as class "_", but either seems to
     ;; work:
     (modify-syntax-entry ?| "." table)
+    (modify-syntax-entry ?- "." table)
+    (modify-syntax-entry ?+ "." table)
+    (modify-syntax-entry ?* "." table)
+    (modify-syntax-entry ?/ "." table)
+    (modify-syntax-entry ?< "." table)
+    (modify-syntax-entry ?> "." table)
     (modify-syntax-entry ?_ "_" table)
     (modify-syntax-entry ?? "w" table)
     (modify-syntax-entry ?~ "w" table)


### PR DESCRIPTION
`-` is subtraction in elixir, not part of a symbol, though I may be missing something.