### PR TITLE
Correct indentation after a one line 'fn' definition

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -379,6 +379,13 @@
       ((and (smie-rule-parent-p "after")
             (smie-rule-hanging-p))
        (smie-rule-parent elixir-smie-indent-basic))
+      ;; Correct indentation after a one-line fn definition
+      ;; Example:
+      ;;
+      ;;  sum = Enum.reduce(dbms, fn(x, sum) -> x + sum end)
+      ;;  average_dbm = sum / length(addresses)
+      ((smie-rule-parent-p "fn")
+       (smie-rule-parent elixir-smie-indent-basic))
       (t
        (smie-rule-parent))))
     (`(:before . "fn")

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1688,6 +1688,21 @@ some_method :arg1,
 other_method
 ")
 
+(elixir-def-indentation-test indent-correct-inside-fn-block
+                             (:tags '(indentation))
+"
+Enum.map(addresses, fn({mac_address, dbms}) ->
+sum = Enum.reduce(dbms, fn(x, sum) -> x + sum end)
+        average_dbm = sum / length(addresses)
+end)
+"
+"
+Enum.map(addresses, fn({mac_address, dbms}) ->
+  sum = Enum.reduce(dbms, fn(x, sum) -> x + sum end)
+  average_dbm = sum / length(addresses)
+end)
+")
+
 ;; We don't want automatic whitespace cleanup here because of the significant
 ;; whitespace after `Record' above. By setting `whitespace-action' to nil,
 ;; `whitespace-mode' won't automatically clean up trailing whitespace (in my


### PR DESCRIPTION
fixes #311