### PR TITLE
Fix highlighting triple single quote(heredoc)

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -274,7 +274,7 @@ is used to limit the scan."
   (unless (elixir-syntax-in-string-or-comment-p)
     (let ((heredoc-p (save-excursion
                        (goto-char (match-beginning 0))
-                       (looking-at-p "~[sS]\"\"\""))))
+                       (looking-at-p "~[sS]\\(?:'''\\|\"\"\"\\)"))))
       (unless heredoc-p
         (forward-char 1)
         (let* ((start-delim (char-after (1- (point))))

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -441,6 +441,23 @@ end
 "
    (should (eq (elixir-test-face-at 33) 'font-lock-string-face))))
 
+(ert-deftest elixir-mode-syntax-table/single-triple-single-quote ()
+  "https://github.com/elixir-lang/emacs-elixir/issues/309"
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+   "defmodule Module do
+  @moduledoc ~S'''
+  foo's \"bar\"
+'''"
+   (should (eq (elixir-test-face-at 34) 'font-lock-builtin-face)) ;; ~S
+   (should (eq (elixir-test-face-at 35) 'font-lock-builtin-face))
+   (should (eq (elixir-test-face-at 36) 'font-lock-string-face))  ;; '''
+   (should (eq (elixir-test-face-at 37) 'font-lock-string-face))
+   (should (eq (elixir-test-face-at 38) 'font-lock-string-face))
+   (should (eq (elixir-test-face-at 54) 'font-lock-string-face))  ;; '''
+   (should (eq (elixir-test-face-at 55) 'font-lock-string-face))
+   (should (eq (elixir-test-face-at 56) 'font-lock-string-face))))
+
 (ert-deftest elixir-mode-syntax-table/gray-out-ignored-var ()
   "https://github.com/elixir-lang/emacs-elixir/issues/292"
   :tags '(fontification syntax-table)


### PR DESCRIPTION
This is related to #309.

#### Before

![before](https://cloud.githubusercontent.com/assets/248290/13898603/c552099c-edd6-11e5-84f0-6c2c702593f9.png)

#### With this patch

![after](https://cloud.githubusercontent.com/assets/554281/14013621/d3882898-f1f0-11e5-8959-440451ab6f30.png)