### PR TITLE
Fix invalid highlighting '::' in binaries

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -424,7 +424,7 @@ is used to limit the scan."
      1 elixir-ignored-var-face)
 
     ;; Map keys
-    (,(elixir-rx (group (and (one-or-more identifiers) ":")))
+    (,(elixir-rx (group (and (one-or-more identifiers) ":")) space)
      1 elixir-atom-face)
 
     ;; Pseudovariables

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -222,7 +222,12 @@ true_false_nil
     (should (eq (elixir-test-face-at 3) 'elixir-atom-face))
     (should (eq (elixir-test-face-at 4) 'elixir-atom-face))
     (should (eq (elixir-test-face-at 9) 'elixir-atom-face))
-    (should (eq (elixir-test-face-at 10) 'elixir-atom-face))))
+    (should (eq (elixir-test-face-at 10) 'elixir-atom-face)))
+
+  ;; https://github.com/elixir-lang/emacs-elixir/issues/320
+  (elixir-test-with-temp-buffer
+   "<<foo::bar>>"
+   (should-not (eq (elixir-test-face-at 3) 'elixir-atom-face))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-interpolation ()
   :tags '(fontification interpolation syntax-table)


### PR DESCRIPTION
Append space to map key regex because keyword argument must be followed by space.

This is related to #320.
CC: @tonini @whatyouhide