### PR TITLE
Correct indentation of maps inside lists

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -527,7 +527,10 @@
            (smie-rule-parent))))
       ((and (smie-rule-parent-p "OP")
             (smie-rule-hanging-p))
-       (smie-rule-parent))))
+       (smie-rule-parent))
+      ((smie-rule-parent-p "[")
+       (smie-rule-parent))
+      ))
     (`(:after . "{")
      (cond
       ((smie-rule-hanging-p)

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1834,6 +1834,41 @@ cond do
 end
 ")
 
+(elixir-def-indentation-test indent-maps-inside-list
+                             (:tags '(indentation))
+"
+[
+%{
+ name: \"John Doe\",
+  email: \"john@doe.org\"
+},
+%{
+        name: \"Jane Doe\",
+email: \"jane@doe.org\",
+},
+%{
+  name: \"Josie Doe\",
+    email: \"josie@doe.org\",
+  },
+]
+"
+"
+[
+  %{
+    name: \"John Doe\",
+    email: \"john@doe.org\"
+  },
+  %{
+    name: \"Jane Doe\",
+    email: \"jane@doe.org\",
+  },
+  %{
+    name: \"Josie Doe\",
+    email: \"josie@doe.org\",
+  },
+]
+")
+
 ;; We don't want automatic whitespace cleanup here because of the significant
 ;; whitespace after `Record' above. By setting `whitespace-action' to nil,
 ;; `whitespace-mode' won't automatically clean up trailing whitespace (in my


### PR DESCRIPTION
Before:

```elixir
[
  %{
    name: "John Doe",
    email: "john@doe.org"
},  <-----
  %{
    name: "Jane Doe",
    email: "jane@doe.org",
  },
  %{
    name: "Josie Doe",
    email: "josie@doe.org",
  },
]
```

After:

```elixir
[
  %{
    name: "John Doe",
    email: "john@doe.org"
  },  <-----
  %{
    name: "Jane Doe",
    email: "jane@doe.org",
  },
  %{
    name: "Josie Doe",
    email: "josie@doe.org",
  },
]
```