### PR TITLE
Correct indent after using 'for' as function name

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -455,7 +455,7 @@
      (cond
       ((elixir-smie-last-line-end-with-block-operator-p)
        (smie-rule-parent elixir-smie-indent-basic))
-      ((smie-rule-prev-p "OP")
+      ((smie-rule-prev-p "OP" "def")
        (smie-rule-parent))))
     (`(:before . "do:")
      (cond

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1918,6 +1918,25 @@ email: \"jane@doe.org\",
 ]
 ")
 
+(elixir-def-indentation-test indent-block-after-for-inside-function-definition
+                             (:tags '(indentation))
+"
+defmodule Test do
+def for(domain) do
+[_, tld] = String.split(domain, \".\", parts: 2)
+Map.fetch(all, tld)
+  end
+end
+"
+"
+defmodule Test do
+  def for(domain) do
+    [_, tld] = String.split(domain, \".\", parts: 2)
+    Map.fetch(all, tld)
+  end
+end
+")
+
 ;; We don't want automatic whitespace cleanup here because of the significant
 ;; whitespace after `Record' above. By setting `whitespace-action' to nil,
 ;; `whitespace-mode' won't automatically clean up trailing whitespace (in my


### PR DESCRIPTION
fixes #330