### PR TITLE
Fix invalid highlighting question quote

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -302,6 +302,14 @@ is used to limit the scan."
     (goto-char start)
     (funcall
      (syntax-propertize-rules
+      ("\\(\\?\\)[\"']"
+       (1 (if (save-excursion (nth 3 (syntax-ppss (match-beginning 0))))
+              ;; Within a string, skip.
+              (ignore
+               (goto-char (match-end 1)))
+            (put-text-property (match-end 1) (match-end 0)
+                               'syntax-table (string-to-syntax "_"))
+            (string-to-syntax "'"))))
       ((elixir-rx string-delimiter)
        (0 (ignore (elixir-syntax-stringify))))
       ((elixir-rx sigils)

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -522,6 +522,17 @@ end
     (should (eq (elixir-test-face-at 53) 'font-lock-string-face)) ;; '<>'
     )))
 
+(ert-deftest elixir-mode-syntax-table/question-quote ()
+  "https://github.com/elixir-lang/emacs-elixir/issues/185"
+  :tags '(fontification syntax-table hoge)
+  (elixir-test-with-temp-buffer
+   "\"\\\"foo\\\"\" |> String.strip(?\")"
+   (should-not (eq (elixir-test-face-at 28) 'font-lock-string-face)))
+
+  (elixir-test-with-temp-buffer
+   "\"\\\"foo\\\"\" |> String.strip(?')"
+   (should-not (eq (elixir-test-face-at 28) 'font-lock-string-face))))
+
 (provide 'elixir-mode-font-test)
 
 ;;; elixir-mode-font-test.el ends here


### PR DESCRIPTION
This is related to #185.
CC: @gausby 

#### Original

![original](https://cloud.githubusercontent.com/assets/554281/14701794/f86ed7c2-07e1-11e6-9037-a1c04f8757f7.png)

#### With this PR

![fixed](https://cloud.githubusercontent.com/assets/554281/14701802/0081e4cc-07e2-11e6-963b-301162848e2e.png)

