### PR TITLE
Correct default indent after match

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -432,9 +432,7 @@
       ((and (smie-rule-parent-p "MATCH-STATEMENT-DELIMITER")
             (smie-rule-hanging-p)
             (smie-rule-sibling-p))
-       (if (elixir-smie-last-line-end-with-block-operator-p)
-           (smie-rule-parent)
-         0))
+       (smie-rule-parent))
       ((and (smie-rule-parent-p "after")
             (smie-rule-hanging-p))
        (smie-rule-parent elixir-smie-indent-basic))
@@ -583,7 +581,11 @@
              (move-end-of-line 1)
              (looking-back elixir-smie--block-operator-regexp (- (point) 3) t))
            (smie-rule-parent (- elixir-smie-indent-basic))
-         (smie-rule-parent)))))
+         (if (save-excursion
+	       (move-beginning-of-line 1)
+	       (looking-at "^.+->.+$"))
+	     (smie-rule-parent (- elixir-smie-indent-basic))
+	   (smie-rule-parent))))))
     (`(:after . "{")
      (cond
       ((smie-rule-hanging-p)

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1513,22 +1513,18 @@ end")
                              (:tags '(indentation))
 "
 case parse do
-{ [ help: true ], _, _ }
-           -> :help
-{ _, [ user, project, count ], _ }
-    -> { user, project, count }
-  { _, [ user, project ], _ }
-  -> { user, project, @default_count }
+{ [ help: true ], _, _ } -> :help
+{ _, [ user, project, count ], _ } ->
+{ user, project, count }
+  { _, [ user, project ], _ } -> { user, project, @default_count }
   _ -> :help
 end"
 "
 case parse do
-  { [ help: true ], _, _ }
-    -> :help
-  { _, [ user, project, count ], _ }
-    -> { user, project, count }
-  { _, [ user, project ], _ }
-    -> { user, project, @default_count }
+  { [ help: true ], _, _ } -> :help
+  { _, [ user, project, count ], _ } ->
+    { user, project, count }
+  { _, [ user, project ], _ } -> { user, project, @default_count }
   _ -> :help
 end")
 
@@ -1585,6 +1581,23 @@ fn x ->
   if true do
   end
 end")
+
+(elixir-def-indentation-test complex-case-with-matches/5
+                             (:tags '(indentation))
+"
+case parse do
+  {} -> :help
+   {} -> :help
+_
+end
+"
+"
+case parse do
+  {} -> :help
+  {} -> :help
+  _
+end
+")
 
 (elixir-def-indentation-test case-with-multiline-maps
                              (:tags '(indentation))


### PR DESCRIPTION
related to #255