### PR TITLE
Add correct indentation for 'with' keyword

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -413,13 +413,16 @@
             (smie-rule-parent-p "do:"))
        (smie-rule-parent))
       ((smie-rule-parent-p ";")
-       (smie-rule-parent ))
+       (smie-rule-parent))
       (t (smie-rule-parent (- elixir-smie-indent-basic)))))
     (`(:before . "MATCH-STATEMENT-DELIMITER")
      (cond
       ((and (smie-rule-parent-p "do")
             (smie-rule-hanging-p))
        (smie-rule-parent))
+      ((and (smie-rule-parent-p "do")
+            (not (smie-rule-hanging-p)))
+       (smie-rule-parent elixir-smie-indent-basic))
       ((and (smie-rule-parent-p "fn"))
        (smie-rule-parent elixir-smie-indent-basic))
       ;; There is a case when between two line inside a def block
@@ -629,12 +632,6 @@
       ((and (smie-rule-parent-p "OP")
             (smie-rule-hanging-p))
        (smie-rule-parent))
-      ((smie-rule-parent-p "->")
-       (if (save-excursion
-             (move-end-of-line 1)
-             (looking-back elixir-smie--block-operator-regexp (- (point) 3) t))
-           (smie-rule-parent (- elixir-smie-indent-basic))
-         elixir-smie-indent-basic))
       ((smie-rule-parent-p ";")
        (if (save-excursion
              (move-end-of-line 1)

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -695,6 +695,70 @@ end
   do: :ok
 )")
 
+(elixir-def-indentation-test with-statement
+			     (:tags '(indentation))
+"
+defmodule Foo do
+
+def bar do
+with {:ok, width} <- Map.fetch(opts, :width),
+{:ok, height} <- Map.fetch(opts, :height) do
+{:ok, width * height}
+else
+:error ->
+{:error, :wrong_data}
+end
+end
+
+end
+"
+
+"
+defmodule Foo do
+
+  def bar do
+    with {:ok, width} <- Map.fetch(opts, :width),
+         {:ok, height} <- Map.fetch(opts, :height) do
+      {:ok, width * height}
+    else
+      :error ->
+        {:error, :wrong_data}
+    end
+  end
+
+end
+")
+
+(elixir-def-indentation-test with-statement/2
+			     (:tags '(indentation))
+"
+defmodule Foo do
+  def bar do
+    with {:ok, width} <- Map.fetch(opts, :width),
+         {:ok, height} <- Map.fetch(opts, :height),
+      do: {:ok, width * height}
+
+    with({:ok, width} <- Map.fetch(opts, :width),
+         {:ok, height} <- Map.fetch(opts, :height),
+      do: {:ok, width * height})
+  end
+end
+"
+
+"
+defmodule Foo do
+  def bar do
+    with {:ok, width} <- Map.fetch(opts, :width),
+         {:ok, height} <- Map.fetch(opts, :height),
+      do: {:ok, width * height}
+
+    with({:ok, width} <- Map.fetch(opts, :width),
+         {:ok, height} <- Map.fetch(opts, :height),
+      do: {:ok, width * height})
+  end
+end
+")
+
 (elixir-def-indentation-test indent-heredoc
                              (:tags '(indentation))
   "
@@ -1775,7 +1839,7 @@ defmodule For do
     for {k, v} <- keyword,
       v = process_value(v),
       into: %{} do
-      {v, k}
+        {v, k}
     end
   end
 end
@@ -1935,25 +1999,6 @@ email: \"jane@doe.org\",
     email: \"josie@doe.org\",
   },
 ]
-")
-
-(elixir-def-indentation-test indent-block-after-for-inside-function-definition
-                             (:tags '(indentation))
-"
-defmodule Test do
-def for(domain) do
-[_, tld] = String.split(domain, \".\", parts: 2)
-Map.fetch(all, tld)
-  end
-end
-"
-"
-defmodule Test do
-  def for(domain) do
-    [_, tld] = String.split(domain, \".\", parts: 2)
-    Map.fetch(all, tld)
-  end
-end
 ")
 
 (elixir-def-indentation-test indent-before-comma

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1930,9 +1930,9 @@ end)
 "
 cond do
  is_nil(val) ->
-IO.puts \"OK\"
-              Enum.any?(1..6, fn -> end)
-    true ->
+  IO.puts \"OK\"
+  Enum.any?(1..6, fn -> end)
+true ->
 end
 "
 "
@@ -2096,6 +2096,37 @@ defmodule Foo do
   # two
   # three
 end")
+
+(elixir-def-indentation-test indent-tuples-in-case-statement
+                             (:tags '(indentation))
+"
+defmodule Foo do
+def bar do
+case info do
+:init ->
+{:foo, :bar}
+{:foo, :bar}
+{:foo, :bar}
+{:foo, :bar}
+end
+end
+end
+"
+
+"
+defmodule Foo do
+  def bar do
+    case info do
+      :init ->
+        {:foo, :bar}
+        {:foo, :bar}
+        {:foo, :bar}
+        {:foo, :bar}
+    end
+  end
+end
+"
+			     )
 
 ;; We don't want automatic whitespace cleanup here because of the significant
 ;; whitespace after `Record' above. By setting `whitespace-action' to nil,


### PR DESCRIPTION
related to #349

*Examples*

```elixir
defmodule Foo do

  def bar do
    with {:ok, width} <- Map.fetch(opts, :width),
         {:ok, height} <- Map.fetch(opts, :height) do
      {:ok, width * height}
    else
      :error ->
        {:error, :wrong_data}
    end
  end

end
```

```elixir

defmodule Foo do
  def bar do
    with {:ok, width} <- Map.fetch(opts, :width),
	     {:ok, height} <- Map.fetch(opts, :height),
      do: {:ok, width * height}
  end
end

```

```elixir
defmodule Foo do
  def bar do
    with({:ok, width} <- Map.fetch(opts, :width),
         {:ok, height} <- Map.fetch(opts, :height),
      do: {:ok, width * height})
  end
end
```

This PR will also fixes #351