### PR TITLE
Remove elixir-negation-face in favor of font-lock

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -72,16 +72,6 @@
 (defvar elixir-key-label-offset 0)
 (defvar elixir-match-label-offset 2)
 
-(defvar elixir-negation-face 'elixir-negation-face)
-(defface elixir-negation-face
-  '((((class color) (min-colors 88) (background light))
-     :foreground "#ff4500")
-    (((class color) (background dark))
-     (:foreground "#ff4500"))
-    (t nil))
-  "For use with standalone \"?\" to indicate code point."
-  :group 'font-lock-faces)
-
 (defvar elixir-attribute-face 'elixir-attribute-face)
 (defface elixir-attribute-face
   '((((class color) (min-colors 88) (background light))
@@ -145,7 +135,7 @@
       (builtin-namespace . ,(rx symbol-start
                                 (or "import" "require" "use" "alias")
                                 symbol-end))
-      ;; Set aside code point syntax for `elixir-negation-face'.
+      ;; Set aside code point syntax for negation face.
       (code-point . ,(rx symbol-start
                          "?"
                          anything
@@ -431,7 +421,7 @@ is used to limit the scan."
 
     ;; Code points
     (,(elixir-rx (group code-point))
-     1 elixir-negation-face)))
+     1 font-lock-negation-char-face)))
 
 ;;;###autoload
 (defun elixir-mode-open-modegithub ()


### PR DESCRIPTION
Font lock [defines a `font-lock-negation-char-face`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Faces-for-Font-Lock.html) so we don't need a special face definition for it.

This might confuse the users though, as the elixir mode negation face is red and now the theme will take over—for my theme negation chars will become blue—but I think this will be better in the long run as more themes will support elixir-mode.

This relates to #352 but does not completely resolve it.