### PR TITLE
Remove `ignored-var-face` in favor of comment-face

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -102,16 +102,6 @@
   "For use with atoms & map keys."
   :group 'font-lock-faces)
 
-(defvar elixir-ignored-var-face 'elixir-ignored-var-face)
-(defface elixir-ignored-var-face
-  '((((class color) (min-colors 88) (background light))
-     :foreground "#424242")
-    (((class color) (background dark))
-     (:foreground "#616161"))
-    (t nil))
-  "For use with ignored variables (starting with underscore)."
-  :group 'font-lock-faces)
-
 (eval-when-compile
   (defconst elixir-rx-constituents
     `(
@@ -419,7 +409,7 @@ is used to limit the scan."
                              (any "A-Z" "a-z" "0-9"))
                         (zero-or-more (any "A-Z" "a-z" "0-9" "_"))
                         (optional (or "?" "!"))))
-     1 elixir-ignored-var-face)
+     1 font-lock-comment-face)
 
     ;; Map keys
     (,(elixir-rx (group (and (one-or-more identifiers) ":")) space)

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -463,7 +463,7 @@ end
    (should (eq (elixir-test-face-at 55) 'font-lock-string-face))
    (should (eq (elixir-test-face-at 56) 'font-lock-string-face))))
 
-(ert-deftest elixir-mode-syntax-table/gray-out-ignored-var ()
+(ert-deftest elixir-mode-syntax-table/comment-out-ignored-var ()
   "https://github.com/elixir-lang/emacs-elixir/issues/292"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
@@ -476,14 +476,14 @@ end
     __MODULE__
 "
    (should (eq (elixir-test-face-at 4) nil))
-   (should (eq (elixir-test-face-at 14) 'elixir-ignored-var-face))
-   (should (eq (elixir-test-face-at 15) 'elixir-ignored-var-face))
-   (should (eq (elixir-test-face-at 23) 'elixir-ignored-var-face))
-   (should (eq (elixir-test-face-at 24) 'elixir-ignored-var-face))
-   (should (eq (elixir-test-face-at 30) 'elixir-ignored-var-face))
-   (should (eq (elixir-test-face-at 32) 'elixir-ignored-var-face))
-   (should (eq (elixir-test-face-at 38) 'elixir-ignored-var-face))
-   (should (eq (elixir-test-face-at 40) 'elixir-ignored-var-face))
+   (should (eq (elixir-test-face-at 14) 'font-lock-comment-face))
+   (should (eq (elixir-test-face-at 15) 'font-lock-comment-face))
+   (should (eq (elixir-test-face-at 23) 'font-lock-comment-face))
+   (should (eq (elixir-test-face-at 24) 'font-lock-comment-face))
+   (should (eq (elixir-test-face-at 30) 'font-lock-comment-face))
+   (should (eq (elixir-test-face-at 32) 'font-lock-comment-face))
+   (should (eq (elixir-test-face-at 38) 'font-lock-comment-face))
+   (should (eq (elixir-test-face-at 40) 'font-lock-comment-face))
    (should (eq (elixir-test-face-at 46) 'font-lock-constant-face))
    (should (eq (elixir-test-face-at 46) 'font-lock-constant-face))
    (should (eq (elixir-test-face-at 52) 'font-lock-constant-face))


### PR DESCRIPTION
To support more themes we it would probably be better to have ignored variables (starting with an underscore) highlighted with the comment face.

This relates to, but does not resolve, #352 