### PR TITLE
Added a failing test for indenting maps with sting as keys

### DIFF
--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1511,6 +1511,23 @@ defmodule Foo do
   end
 end")
 
+(elixir-def-indentation-test indent-maps-with-stings-as-keys
+                             (:expected-result :failed :tags '(indentation))
+"%{
+\"data\" => %{
+\"foo\" => %{
+\"bar\" => nil
+}
+}
+}"
+"%{
+  \"data\" => %{
+    \"foo\" => %{
+      \"bar\" => nil
+    }
+  }
+}")
+
 (elixir-def-indentation-test indent-maps-and-structs-elements
                              (:tags '(indentation))
 "


### PR DESCRIPTION
It assumes the following indentation to be correct:
```elixir
%{
  "data" => %{
    "foo" => %{
      "bar" => nil
    }
  }
}
```
This relates to #359