### PR TITLE
Fontify ~D() sigil

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -167,7 +167,7 @@
                          (or "_" "__MODULE__" "__DIR__" "__ENV__" "__CALLER__"
                              "__block__" "__aliases__")
                          symbol-end))
-      (sigils . ,(rx "~" (or "B" "C" "R" "S" "b" "c" "r" "s" "w")))))
+      (sigils . ,(rx "~" (or "B" "C" "D" "R" "S" "b" "c" "r" "s" "w")))))
 
   (defmacro elixir-rx (&rest sexps)
     (let ((rx-constituents (append elixir-rx-constituents rx-constituents)))

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -366,7 +366,8 @@ end"
 ~w<\">
 ~s\"\"\"
 foo
-\"\"\""
+\"\"\"
+~D(\")"
    (should-not (eq (elixir-test-face-at 5) 'font-lock-string-face))   ; ~s//
 
    (should-not (eq (elixir-test-face-at 7) 'font-lock-string-face))   ; ~r||
@@ -400,7 +401,9 @@ foo
    (should     (eq (elixir-test-face-at 51) 'font-lock-string-face))  ; ~s""" """
    (should     (eq (elixir-test-face-at 52) 'font-lock-string-face))
    (should     (eq (elixir-test-face-at 53) 'font-lock-string-face))
-   (should     (eq (elixir-test-face-at 55) 'font-lock-string-face))))
+   (should     (eq (elixir-test-face-at 55) 'font-lock-string-face))
+
+   (should     (eq (elixir-test-face-at 66) 'font-lock-string-face)))) ; ~D()
 
 (ert-deftest elixir-mode-syntax-table/hashmark-in-sigils ()
   "Don't treat hashmark in sigils as comment"


### PR DESCRIPTION
This commit adds fontification support to the new date sigil added in Elixir 1.3

Signed-off-by: Milhouse <renanranelli@gmail.com>