### PR TITLE
Fix highlighting ignored variable in pattern match

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -385,14 +385,6 @@ is used to limit the scan."
                  (optional "="))
      1 elixir-atom-face)
 
-    ;; Variable definitions
-    (,(elixir-rx (group identifiers)
-                 (zero-or-more space)
-                 (repeat 1 "=")
-                 (or (or sigils identifiers space)
-                     (one-or-more "\n")))
-     1 font-lock-variable-name-face)
-
     ;; Gray out variables starting with "_"
     (,(elixir-rx symbol-start
                  (group (and "_"
@@ -400,6 +392,14 @@ is used to limit the scan."
                         (zero-or-more (any "A-Z" "a-z" "0-9" "_"))
                         (optional (or "?" "!"))))
      1 font-lock-comment-face)
+
+    ;; Variable definitions
+    (,(elixir-rx (group identifiers)
+                 (zero-or-more space)
+                 (repeat 1 "=")
+                 (or (or sigils identifiers space)
+                     (one-or-more "\n")))
+     1 font-lock-variable-name-face)
 
     ;; Map keys
     (,(elixir-rx (group (and (one-or-more identifiers) ":")) space)

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -527,7 +527,7 @@ end
 
 (ert-deftest elixir-mode-syntax-table/question-quote ()
   "https://github.com/elixir-lang/emacs-elixir/issues/185"
-  :tags '(fontification syntax-table hoge)
+  :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "\"\\\"foo\\\"\" |> String.strip(?\")"
    (should-not (eq (elixir-test-face-at 28) 'font-lock-string-face)))
@@ -535,6 +535,15 @@ end
   (elixir-test-with-temp-buffer
    "\"\\\"foo\\\"\" |> String.strip(?')"
    (should-not (eq (elixir-test-face-at 28) 'font-lock-string-face))))
+
+(ert-deftest elixir-mode-syntax-table/ignored-variables-in-pattern-match ()
+  "https://github.com/elixir-lang/emacs-elixir/issues/361"
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+   "(_1_day = 86_400)
+_1_day"
+   (should (eq (elixir-test-face-at 2) 'font-lock-comment-face))
+   (should (eq (elixir-test-face-at 19) 'font-lock-comment-face))))
 
 (provide 'elixir-mode-font-test)
 


### PR DESCRIPTION
Highlight ignored variable before variable definition highlighting.

This is related to #361.
CC: @whatyouhide

(And remove needless test tag, sorry I added it in my previous commit :bow:)

Screenshot with this change is here.

![after](https://cloud.githubusercontent.com/assets/554281/18754619/43a330c4-8124-11e6-94f6-9830bfb0ea1b.png)


